### PR TITLE
fix(types): update type defs

### DIFF
--- a/packages/node/dist/types.d.ts
+++ b/packages/node/dist/types.d.ts
@@ -1,4 +1,4 @@
 declare module "@beam-australia/react-env" {
-    function env(key: string): string
+    function env(key?: string): string | undefined
     export = env
 }


### PR DESCRIPTION
This removes the typescript warnings which appear when no argument is given. fix #116 